### PR TITLE
Fix: Zen Dots font

### DIFF
--- a/src/pages/firstdate/home/index.astro
+++ b/src/pages/firstdate/home/index.astro
@@ -10,15 +10,15 @@ import BlurText from "@common/BlurText.astro";
     <div class="flex flex-col items-center justify-center w-full mt-5">
       <BlurText 
         textSize="text-xl" 
-        className="text-white" 
-        blurClassName="text-[#FFE4E1] blur-[1.75px] translate-x-[2px] translate-y-[2px]"
+        className="text-white font-zen-dots" 
+        blurClassName="text-[#FFE4E1] blur-[1.75px] translate-x-[2px] translate-y-[2px] font-zen-dots"
       >
         Welcome
       </BlurText>
       <BlurText 
         textSize="text-3xl" 
-        className="text-[#CB438B]" 
-        blurClassName="text-[#CB438B] blur-[3px] translate-y-[2px]"
+        className="text-[#CB438B] font-zen-dots" 
+        blurClassName="text-[#CB438B] blur-[3px] translate-y-[2px] font-zen-dots"
       >
         CU109
       </BlurText>
@@ -26,8 +26,8 @@ import BlurText from "@common/BlurText.astro";
     <div>
       <BlurText 
         textSize="text-lg" 
-        className="text-white" 
-        blurClassName="text-black blur-xs translate-y-[3px]"
+        className="text-white font-zen-dots" 
+        blurClassName="text-black blur-xs translate-y-[3px] font-zen-dots"
       >
         Activities
       </BlurText>
@@ -51,8 +51,8 @@ import BlurText from "@common/BlurText.astro";
     <div class="pb-6">
       <BlurText 
         textSize="text-lg" 
-        className="text-white" 
-        blurClassName="text-black blur-xs translate-y-[3px]"
+        className="text-white font-zen-dots" 
+        blurClassName="text-black blur-xs translate-y-[3px] font-zen-dots"
       >
         More
       </BlurText>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -14,6 +14,11 @@ body {
   font-family: 'IBM Plex Sans Thai', sans-serif;
 }
 
+@theme {
+  --font-zen-dots: 'Zen Dots', 'sans-serif';
+  --font-ibm-plex-sans-thai: 'IBM Plex Sans Thai', 'sans-serif';
+}
+
 /* Cut edge Classes */
 
 /* Spec 

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -4,8 +4,6 @@ export default {
   theme: {
     extend: {
       fontFamily: {
-        'zen-dots': ['"Zen Dots"', 'cursive'],
-        'ibm-plex-thai': ['IBM Plex Sans Thai', 'sans-serif'],
       },
     },
   },


### PR DESCRIPTION
This pull request updates the styling of text elements in the `src/pages/firstdate/home/index.astro` file and introduces new font variables in the global stylesheet. The most significant change is the addition of the `font-zen-dots` class to enhance visual consistency across text elements.

### Styling updates in `index.astro`:

* Applied the `font-zen-dots` class to all instances of `BlurText` components, ensuring consistent typography for both `className` and `blurClassName` properties. This affects text elements such as "Welcome," "CU109," "Activities," and "More." [[1]](diffhunk://#diff-4af2e0313d5f2b07605d66a6197e27bc5d66e9d2de103e18815e7cbf1248f2c3L13-R30) [[2]](diffhunk://#diff-4af2e0313d5f2b07605d66a6197e27bc5d66e9d2de103e18815e7cbf1248f2c3L54-R55)

### Global stylesheet updates:

* Added new theme variables `--font-zen-dots` and `--font-ibm-plex-sans-thai` to the `@theme` section in `src/styles/global.css` for easier font management and reusability.