### PR TITLE
fix: popup size behavior changed to control by class

### DIFF
--- a/src/components/common/Popup.astro
+++ b/src/components/common/Popup.astro
@@ -1,6 +1,6 @@
 ---
 /**
- * Popup Component - Fancy containers that actually work
+ * Popup Component
  * 
  * @example
  * ```astro
@@ -82,31 +82,29 @@ const borderSvg = `/images/popup-borders/popup-border-${size}-${color}.svg`;
 ---
 
 <div 
-  class={`popup-container relative w-full ${className}`}
+  class="popup-container w-screen"
   data-size={size}
   style={`
+    position: relative;
     aspect-ratio: ${config.aspectRatio};
     min-height: ${config.minHeight};
   `}
 >
-  <!-- Background with border SVG -->
-  <div 
-    class="absolute inset-0 bg-contain bg-center bg-no-repeat"
-    style={`background-image: url('${borderSvg}'); background-size: 100% 100%;`}
-  ></div>
   
-  <!-- Content area positioned within SVG bounds with proper clipping -->
+  <img 
+    src={borderSvg}
+    alt=""
+    class="absolute inset-0 w-full h-full object-contain"
+  />
+  
+  <!-- Content Area -->
   <div 
-    class="absolute flex items-center justify-center content-area popup-content-clip"
+    class="absolute inset-0 z-10"
     style={`
-      left: 50%;
-      top: 50%;
-      width: ${config.contentWidth};
-      height: ${config.contentHeight};
-      transform: translate(-50%, -50%);
+      padding: ${size === 'large' ? '15%' : '12%'};
     `}
   >
-    <div class="text-center w-full px-4 h-full overflow-y-auto">
+    <div class={`w-full h-full overflow-hidden ${className}`}>
       <slot />
     </div>
   </div>

--- a/src/components/common/Popup.astro
+++ b/src/components/common/Popup.astro
@@ -1,4 +1,6 @@
 ---
+import { cn } from '@/lib/utils';
+
 /**
  * Popup Component
  * 
@@ -58,7 +60,7 @@ export interface Props {
 const { 
   size = 'large', 
   color = 'black',
-  class: className = ''
+  class: additionalClasses = ''
 } = Astro.props;
 
 // Configuration based on size
@@ -104,7 +106,7 @@ const borderSvg = `/images/popup-borders/popup-border-${size}-${color}.svg`;
       padding: ${size === 'large' ? '15%' : '12%'};
     `}
   >
-    <div class={`w-full h-full overflow-hidden ${className}`}>
+    <div class={cn("w-full h-full overflow-hidden", additionalClasses)}>
       <slot />
     </div>
   </div>


### PR DESCRIPTION
# Summary
- this fix is due to the popup component is fixed by itself and cannot bypass by class. 
- fix children <slot /> overflow from parent component
- this error makes Popup component arranged in wrong way and hard to implement
- styling by class

# Example
you can implement class within class. for example, **`class="flex flex-col items-center justify-center text-center"`**
```astro
<Popup
    size="large"   
    color="vivid-pink"                                     
    class="flex flex-col items-center justify-center text-center"
>
    <p class="text-lg text-white">หากคุณพบเหตุฉุกเฉินหรือมีความต้องการความช่วยเหลือด่วน กรุณาติดต่อหน่วยงานที่เกี่ยวข้องตามข้อมูลด้านล่างนี้</p>
</Popup>
```

| Before      | Fixed |
| ----------- | ----------- |
| ![Before Change](https://github.com/user-attachments/assets/a16b3d4a-62e0-4b1b-b98c-5702d2c61047)      | ![Fixed](https://github.com/user-attachments/assets/e85112dc-f5a8-4d9b-8b1e-115cf511023b)       |





