### PR TITLE
feat: add medium size support to Popup component

### DIFF
--- a/public/images/popup-borders/popup-border-medium-light-beige.svg
+++ b/public/images/popup-borders/popup-border-medium-light-beige.svg
@@ -1,0 +1,21 @@
+<svg width="376" height="495" viewBox="0 0 376 495" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g filter="url(#filter0_d_893_35185)">
+<foreignObject x="15.5332" y="17.9492" width="339.693" height="451.785"><div xmlns="http://www.w3.org/1999/xhtml" style="backdrop-filter:blur(5px);clip-path:url(#bgblur_0_893_35185_clip_path);height:100%;width:100%"></div></foreignObject><path data-figma-bg-blur-radius="10" d="M25.5332 108.011L95.6559 27.9492L345.226 28.6335V376.935L277.312 459.733H25.5332V108.011Z" fill="#121212" fill-opacity="0.5"/>
+<path d="M357.956 257.115C361.294 257.115 364 260.314 364 264.259C364 267.745 361.885 270.641 359.09 271.269V388.022L283.642 477.196H174.665C174.134 480.501 171.681 483.001 168.731 483.001C165.394 483.001 162.688 479.802 162.688 475.857C162.688 471.912 165.394 468.714 168.731 468.714C171.681 468.714 174.134 471.214 174.665 474.518H282.704L356.823 386.913V271.269C354.028 270.641 351.913 267.745 351.913 264.259C351.913 260.314 354.619 257.115 357.956 257.115Z" fill="#FFFFF2"/>
+<path d="M169.809 4C173.146 4 175.853 7.19871 175.853 11.1434C175.853 15.0882 173.146 18.2869 169.809 18.2869C166.859 18.2869 164.406 15.7868 163.876 12.4827H90.962L11.1769 106.783V187.605C13.9725 188.233 16.0877 191.131 16.0877 194.618C16.0876 198.563 13.3813 201.761 10.0439 201.761C6.70639 201.761 4.00009 198.563 4 194.618C4 191.131 6.11522 188.233 8.91077 187.605V105.674L90.0237 9.8042H163.876C164.406 6.50003 166.859 4 169.809 4Z" fill="#FFFFF2"/>
+<path d="M83.6943 469.16H24.7734V107.014L94.5557 27.2139H251.391L267.254 16.5H346.569V377.308L277.921 461.125H97.291L83.6943 469.16ZM27.04 108.122V458.446H276.982L344.304 376.199V29.8926H95.4941L27.04 108.122Z" fill="#FFFFF2"/>
+</g>
+<defs>
+<filter id="filter0_d_893_35185" x="0" y="0" width="376" height="495" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="4" dy="4"/>
+<feGaussianBlur stdDeviation="4"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 0.94902 0 0 0 1 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_893_35185"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_893_35185" result="shape"/>
+</filter>
+<clipPath id="bgblur_0_893_35185_clip_path" transform="translate(-15.5332 -17.9492)"><path d="M25.5332 108.011L95.6559 27.9492L345.226 28.6335V376.935L277.312 459.733H25.5332V108.011Z"/>
+</clipPath></defs>
+</svg>

--- a/public/images/popup-borders/popup-border-medium-light-green.svg
+++ b/public/images/popup-borders/popup-border-medium-light-green.svg
@@ -1,0 +1,21 @@
+<svg width="376" height="496" viewBox="0 0 376 496" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g filter="url(#filter0_d_893_35244)">
+<foreignObject x="15.5332" y="18.4492" width="339.693" height="451.785"><div xmlns="http://www.w3.org/1999/xhtml" style="backdrop-filter:blur(5px);clip-path:url(#bgblur_0_893_35244_clip_path);height:100%;width:100%"></div></foreignObject><path data-figma-bg-blur-radius="10" d="M25.5332 108.511L95.6559 28.4492L345.226 29.1335V377.435L277.312 460.233H25.5332V108.511Z" fill="#121212" fill-opacity="0.5"/>
+<path d="M357.956 257.615C361.294 257.615 364 260.814 364 264.759C364 268.245 361.885 271.141 359.09 271.769V388.522L283.642 477.696H174.665C174.134 481.001 171.681 483.501 168.731 483.501C165.394 483.501 162.688 480.302 162.688 476.357C162.688 472.412 165.394 469.214 168.731 469.214C171.681 469.214 174.134 471.714 174.665 475.018H282.704L356.823 387.413V271.769C354.028 271.141 351.913 268.245 351.913 264.759C351.913 260.814 354.619 257.615 357.956 257.615Z" fill="#C6EBC5"/>
+<path d="M169.809 4.5C173.146 4.5 175.853 7.69871 175.853 11.6434C175.853 15.5882 173.146 18.7869 169.809 18.7869C166.859 18.7869 164.406 16.2868 163.876 12.9827H90.962L11.1769 107.283V188.105C13.9725 188.733 16.0877 191.631 16.0877 195.118C16.0876 199.063 13.3813 202.261 10.0439 202.261C6.70639 202.261 4.00009 199.063 4 195.118C4 191.631 6.11522 188.733 8.91077 188.105V106.174L90.0237 10.3042H163.876C164.406 7.00003 166.859 4.5 169.809 4.5Z" fill="#C6EBC5"/>
+<path d="M83.6943 469.66H24.7734V107.514L94.5557 27.7139H251.391L267.254 17H346.569V377.808L277.921 461.625H97.291L83.6943 469.66ZM27.04 108.622V458.946H276.982L344.304 376.699V30.3926H95.4941L27.04 108.622Z" fill="#C6EBC5"/>
+</g>
+<defs>
+<filter id="filter0_d_893_35244" x="0" y="0.5" width="376" height="495" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="4" dy="4"/>
+<feGaussianBlur stdDeviation="4"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0.776471 0 0 0 0 0.921569 0 0 0 0 0.772549 0 0 0 1 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_893_35244"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_893_35244" result="shape"/>
+</filter>
+<clipPath id="bgblur_0_893_35244_clip_path" transform="translate(-15.5332 -18.4492)"><path d="M25.5332 108.511L95.6559 28.4492L345.226 29.1335V377.435L277.312 460.233H25.5332V108.511Z"/>
+</clipPath></defs>
+</svg>

--- a/public/images/popup-borders/popup-border-medium-light-pink.svg
+++ b/public/images/popup-borders/popup-border-medium-light-pink.svg
@@ -1,0 +1,45 @@
+<svg width="378" height="528" viewBox="0 0 378 528" fill="none" xmlns="http://www.w3.org/2000/svg">
+<foreignObject x="20.5332" y="19.6504" width="339.693" height="482.434"><div xmlns="http://www.w3.org/1999/xhtml" style="backdrop-filter:blur(5px);clip-path:url(#bgblur_0_904_20468_clip_path);height:100%;width:100%"></div></foreignObject><path data-figma-bg-blur-radius="10" d="M30.5332 115.395L100.656 29.6504L350.226 30.3832V403.408L282.312 492.083H30.5332V115.395Z" fill="#121212" fill-opacity="0.5"/>
+<g filter="url(#filter1_d_904_20468)">
+<path d="M88.6943 502.179H29.7734V114.327L99.5557 28.8633H256.391L272.254 17.3887H351.569V403.807L282.921 493.573H102.291L88.6943 502.179ZM32.04 115.515V490.705H281.982L349.304 402.619V31.7314H100.494L32.04 115.515Z" fill="#FFFFF2"/>
+</g>
+<g filter="url(#filter2_d_904_20468)">
+<path d="M363.269 275C364.378 275 365.417 275.38 366.311 276.041C368.518 277.346 370 279.749 370 282.5C370 284.699 369.053 286.676 367.546 288.048C366.705 289.112 365.619 289.866 364.402 290.158V415.199L288.954 510.703H180.79C180.029 513.746 177.278 516 174 516C170.134 516 167 512.866 167 509C167 505.134 170.134 502 174 502C177.469 502 180.346 504.523 180.901 507.834H288.017L362.136 414.012V290.158C361.886 290.098 361.642 290.017 361.403 289.919C357.781 289.388 355 286.27 355 282.5C355 278.358 358.358 275 362.5 275C362.643 275 362.784 275.005 362.925 275.013C363.039 275.005 363.153 275 363.269 275Z" fill="#CB438B"/>
+</g>
+<g filter="url(#filter3_d_904_20468)">
+<path d="M175.5 4C179.642 4 183 7.35786 183 11.5C183 15.6421 179.642 19 175.5 19C171.902 19 168.896 16.4658 168.169 13.085H95.9619L16.1768 114.079V200.031C20.0017 200.373 23 203.586 23 207.5C23 211.642 19.6421 215 15.5 215C11.3579 215 8 211.642 8 207.5C8 203.903 10.5323 200.899 13.9111 200.17V112.892L95.0234 10.2158H168.111C168.721 6.68566 171.796 4 175.5 4Z" fill="#CB438B"/>
+</g>
+<defs>
+<clipPath id="bgblur_0_904_20468_clip_path" transform="translate(-20.5332 -19.6504)"><path d="M30.5332 115.395L100.656 29.6504L350.226 30.3832V403.408L282.312 492.083H30.5332V115.395Z"/>
+</clipPath><filter id="filter1_d_904_20468" x="21.7734" y="13.3887" width="337.797" height="500.791" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="4"/>
+<feGaussianBlur stdDeviation="4"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 1 0 0 0 0 1 0 0 0 0 0.94902 0 0 0 1 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_904_20468"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_904_20468" result="shape"/>
+</filter>
+<filter id="filter2_d_904_20468" x="159" y="271" width="219" height="257" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="4"/>
+<feGaussianBlur stdDeviation="4"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0.796078 0 0 0 0 0.262745 0 0 0 0 0.545098 0 0 0 1 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_904_20468"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_904_20468" result="shape"/>
+</filter>
+<filter id="filter3_d_904_20468" x="0" y="0" width="191" height="227" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dy="4"/>
+<feGaussianBlur stdDeviation="4"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0.796078 0 0 0 0 0.262745 0 0 0 0 0.545098 0 0 0 1 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_904_20468"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_904_20468" result="shape"/>
+</filter>
+</defs>
+</svg>

--- a/public/images/popup-borders/popup-border-medium-vivid-pink.svg
+++ b/public/images/popup-borders/popup-border-medium-vivid-pink.svg
@@ -1,0 +1,21 @@
+<svg width="376" height="495" viewBox="0 0 376 495" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g filter="url(#filter0_d_893_34817)">
+<foreignObject x="15.5332" y="17.9492" width="339.693" height="451.785"><div xmlns="http://www.w3.org/1999/xhtml" style="backdrop-filter:blur(5px);clip-path:url(#bgblur_0_893_34817_clip_path);height:100%;width:100%"></div></foreignObject><path data-figma-bg-blur-radius="10" d="M25.5332 108.011L95.6559 27.9492L345.226 28.6335V376.935L277.312 459.733H25.5332V108.011Z" fill="#121212" fill-opacity="0.5"/>
+<path d="M357.956 257.115C361.294 257.115 364 260.314 364 264.259C364 267.745 361.885 270.641 359.09 271.269V388.022L283.642 477.196H174.665C174.134 480.501 171.681 483.001 168.731 483.001C165.394 483.001 162.688 479.802 162.688 475.857C162.688 471.912 165.394 468.714 168.731 468.714C171.681 468.714 174.134 471.214 174.665 474.518H282.704L356.823 386.913V271.269C354.028 270.641 351.913 267.745 351.913 264.259C351.913 260.314 354.619 257.115 357.956 257.115Z" fill="#CB438B"/>
+<path d="M169.809 4C173.146 4 175.853 7.19871 175.853 11.1434C175.853 15.0882 173.146 18.2869 169.809 18.2869C166.859 18.2869 164.406 15.7868 163.876 12.4827H90.962L11.1769 106.783V187.605C13.9725 188.233 16.0877 191.131 16.0877 194.618C16.0876 198.563 13.3813 201.761 10.0439 201.761C6.70639 201.761 4.00009 198.563 4 194.618C4 191.131 6.11522 188.233 8.91077 187.605V105.674L90.0237 9.8042H163.876C164.406 6.50003 166.859 4 169.809 4Z" fill="#CB438B"/>
+<path d="M83.6943 469.16H24.7734V107.014L94.5557 27.2139H251.391L267.254 16.5H346.569V377.308L277.921 461.125H97.291L83.6943 469.16ZM27.04 108.122V458.446H276.982L344.304 376.199V29.8926H95.4941L27.04 108.122Z" fill="#CB438B"/>
+</g>
+<defs>
+<filter id="filter0_d_893_34817" x="0" y="0" width="376" height="495" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+<feFlood flood-opacity="0" result="BackgroundImageFix"/>
+<feColorMatrix in="SourceAlpha" type="matrix" values="0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 127 0" result="hardAlpha"/>
+<feOffset dx="4" dy="4"/>
+<feGaussianBlur stdDeviation="4"/>
+<feComposite in2="hardAlpha" operator="out"/>
+<feColorMatrix type="matrix" values="0 0 0 0 0.796078 0 0 0 0 0.262745 0 0 0 0 0.545098 0 0 0 1 0"/>
+<feBlend mode="normal" in2="BackgroundImageFix" result="effect1_dropShadow_893_34817"/>
+<feBlend mode="normal" in="SourceGraphic" in2="effect1_dropShadow_893_34817" result="shape"/>
+</filter>
+<clipPath id="bgblur_0_893_34817_clip_path" transform="translate(-15.5332 -17.9492)"><path d="M25.5332 108.011L95.6559 27.9492L345.226 28.6335V376.935L277.312 459.733H25.5332V108.011Z"/>
+</clipPath></defs>
+</svg>

--- a/src/components/common/ButtonFd.astro
+++ b/src/components/common/ButtonFd.astro
@@ -41,8 +41,9 @@
  */
 
 import { Check, X } from '@lucide/astro';
+import { cn } from '@/lib/utils';
 
-export type ColorName = 'light-beige' | 'light-pink' | 'vivid-pink' | 'light-blue' | 'light-green' | 'black' | 'beige';
+export type ColorName = 'light-beige' | 'light-pink' | 'vivid-pink' | 'light-blue' | 'light-green' | 'black' | 'beige' | 'white';
 
 export interface Props {
   variant?: 'fill' | 'stroke';
@@ -58,24 +59,24 @@ const {
   color = 'light-beige',
   size = 'md',
   disabled = false,
-  class: className = '',
+  class: additionalClasses = '',
   registrationStatus = null,
   ...restProps
 } = Astro.props;
 
 const sizeConfig = {
   sm: {
-    container: 'w-[200px] h-[40px]',
+    container: 'w-[200px] min-h-[40px]',
     text: 'text-base',
     padding: 'px-5 py-2'
   },
   md: {
-    container: 'w-[240px] h-[48px]',
+    container: 'w-[240px] min-h-[48px]',
     text: 'text-lg',
     padding: 'px-6 py-3'
   },
   lg: {
-    container: 'w-[260px] h-[48px]',
+    container: 'w-[260px] min-h-[48px]',
     text: 'text-xl',
     padding: 'px-6 py-2.5'
   }
@@ -85,14 +86,21 @@ const currentSize = sizeConfig[size];
 ---
 
 <div 
-  class={`button-container button-container--${variant} button-container--${color} relative inline-block transition-all duration-200 ease-in-out ${currentSize.container} ${disabled ? 'button-container--disabled' : ''} ${className}`}
+  class={cn(
+    'button-container relative inline-block transition-all duration-200 ease-in-out',
+    `button-container--${variant}`,
+    `button-container--${color}`,
+    currentSize.container,
+    disabled && 'button-container--disabled',
+    additionalClasses
+  )}
   data-variant={variant}
   data-color={color}
   data-size={size}
 >
   <!-- SVG Background/Border Pattern -->
   <div class="absolute inset-0 pointer-events-none">
-    <svg class="w-full h-full" viewBox="0 0 264 52" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <svg class="w-full h-full" viewBox="0 0 264 52" fill="none" xmlns="http://www.w3.org/2000/svg" preserveAspectRatio="none">
       <path d="M262 25L236 2H262V25Z" class="svg-triangle"/>
       <path d="M2 40.6341V2H229.702L262 30.0976V50H13.3043L2 40.6341Z" class="svg-fill"/>
       <path d="M262 25L236 2H262V25Z" class="svg-stroke" stroke-width="3"/>
@@ -101,16 +109,27 @@ const currentSize = sizeConfig[size];
   </div>
 
   <button 
-    class={`button-main relative flex items-center justify-center w-full h-full font-ibm-plex-sans-thai font-normal leading-relaxed ${currentSize.text} cursor-pointer transition-colors duration-200 ease-in-out border-0 outline-none bg-transparent focus:outline-none disabled:cursor-not-allowed ${disabled ? 'opacity-50' : ''}`}
+    class={cn(
+      'button-main relative flex items-center w-full font-ibm-plex-sans-thai font-normal leading-tight cursor-pointer transition-colors duration-200 ease-in-out border-0 outline-none bg-transparent focus:outline-none disabled:cursor-not-allowed overflow-hidden',
+      currentSize.text,
+      currentSize.padding,
+      disabled && 'opacity-50'
+    )}
     disabled={disabled}
     data-variant={variant}
     {...restProps}
   >
-    <div class={`flex items-center justify-center gap-2 relative z-10 ${currentSize.padding}`}>
-      <slot name="icon" />
-      <slot />
+    <div class={cn('flex items-center w-full relative z-10 overflow-hidden')}>
+      <div class="flex-shrink-0">
+        <slot name="icon" />
+      </div>
+      <div class="flex-1 flex justify-center overflow-hidden">
+        <div class="text-center leading-tight">
+          <slot />
+        </div>
+      </div>
       {registrationStatus && (
-        <div class="flex items-center justify-center ml-2">
+        <div class="flex items-center justify-center ml-2 flex-shrink-0">
           {registrationStatus === 'registered' ? (
             <div class="w-5 h-5 rounded-full bg-green-500 flex items-center justify-center">
               <Check size={12} color="white" />
@@ -135,9 +154,9 @@ const currentSize = sizeConfig[size];
     --default-stroke: #CB438B;
     --default-text: #121212;
     --default-shadow: #CB438B;
-    --hover-fill: #FFFFF2;
-    --hover-stroke: #CB438B;
-    --hover-text: #121212;
+    --hover-fill: #CB438B;
+    --hover-stroke: #FFFFF2;
+    --hover-text: #FFFFF2;
     --hover-shadow: #CB438B;
     --disabled-fill: rgba(255, 255, 242, 0.5);
     --disabled-stroke: rgba(203, 67, 139, 0.5);
@@ -147,6 +166,34 @@ const currentSize = sizeConfig[size];
   
   /* Stroke variant overrides for light-beige */
   .button-container--stroke.button-container--light-beige {
+    --default-stroke: #FFFFF2;
+    --default-shadow: #FFFFF2;
+    --default-text: #FFFFF2;
+    --hover-fill: #FFFFF2;
+    --hover-stroke: #FFFFF2;
+    --hover-text: #121212;
+    --hover-shadow: #FFFFF2;
+    --disabled-stroke: rgba(255, 255, 242, 0.2);
+    --disabled-text: rgba(255, 255, 242, 0.2);
+    --disabled-shadow: rgba(255, 255, 242, 0.2);
+  }
+  .button-container--white {
+    --default-fill: #FFFFF2;
+    --default-stroke: #FFFFF2;
+    --default-text: #121212;
+    --default-shadow: #FFFFF2;
+    --hover-fill: #121212;
+    --hover-stroke: #FFFFF2;
+    --hover-text: #FFFFF2;
+    --hover-shadow: #121212;
+    --disabled-fill: rgba(255, 255, 242, 0.5);
+    --disabled-stroke: rgba(203, 67, 139, 0.5);
+    --disabled-text: rgba(18, 18, 18, 0.5);
+    --disabled-shadow: rgba(203, 67, 139, 0.5);
+  }
+  
+  /* Stroke variant overrides for light-beige */
+  .button-container--stroke.button-container--white {
     --default-stroke: #FFFFF2;
     --default-shadow: #FFFFF2;
     --default-text: #FFFFF2;

--- a/src/components/common/ButtonRpkm.astro
+++ b/src/components/common/ButtonRpkm.astro
@@ -1,4 +1,6 @@
 ---
+import { cn } from '@/lib/utils';
+
 /**
  * ButtonRpkm
  * @example
@@ -46,7 +48,7 @@ const {
   color = 'purple',
   size = 'md',
   disabled = false,
-  class: className = '',
+  class: additionalClasses = '',
   ...restProps
 } = Astro.props;
 
@@ -99,25 +101,25 @@ const sizeConfig = {
   xs: { 
     classes: 'px-3 py-2 text-sm',
     width: 'w-26',
-    height: 'h-10',
+    height: 'min-h-10',
     iconSize: 16
   },
   sm: { 
     classes: 'px-4 py-3 text-base',
     width: 'w-32',
-    height: 'h-12',
+    height: 'min-h-12',
     iconSize: 18
   },
   md: { 
     classes: 'px-5 py-3 text-lg',
     width: 'w-44',
-    height: 'h-12',
+    height: 'min-h-12',
     iconSize: 20
   },
   lg: { 
     classes: 'px-6 py-3 text-xl',
     width: 'w-64',
-    height: 'h-12',
+    height: 'min-h-12',
     iconSize: 24
   }
 };
@@ -126,8 +128,8 @@ const sizeConfig = {
 const currentColorConfig = colorConfig[color][variant];
 const currentSizeConfig = sizeConfig[size];
 
-// Generate button classes
-const buttonClasses = [
+// Generate button classes using cn utility
+const buttonClasses = cn(
   // Base styles
   'relative inline-flex items-center justify-center font-medium',
   'transition-all duration-200 ease-in-out',
@@ -148,8 +150,8 @@ const buttonClasses = [
   'cut-edge-all',
   
   // Custom classes
-  className
-].filter(Boolean).join(' ');
+  additionalClasses
+);
 
 // Generate gradient background for fill variants
 const getGradientStyle = () => {
@@ -219,7 +221,11 @@ const getSvgBorder = () => {
 ---
 
 <button 
-  class={`${buttonClasses} focus:outline-2 focus:outline-white/30 focus:outline-offset-2 focus:disabled:outline-none ${variant === 'stroke' ? 'bg-no-repeat bg-center bg-contain' : ''}`}
+  class={cn(
+    buttonClasses,
+    'focus:outline-2 focus:outline-white/30 focus:outline-offset-2 focus:disabled:outline-none',
+    variant === 'stroke' && 'bg-no-repeat bg-center bg-contain'
+  )}
   style={`${getGradientStyle()}${getSvgBorder()}`}
   disabled={disabled}
   data-variant={variant}
@@ -227,6 +233,14 @@ const getSvgBorder = () => {
   data-size={size}
   {...restProps}
 >
-  <slot name="icon" />
-  <slot />
+  <div class="flex items-center w-full relative z-10 overflow-hidden">
+    <div class="flex-shrink-0">
+      <slot name="icon" />
+    </div>
+    <div class="flex-1 flex justify-center overflow-hidden">
+      <div class="text-center leading-tight">
+        <slot />
+      </div>
+    </div>
+  </div>
 </button>

--- a/src/components/common/Popup.astro
+++ b/src/components/common/Popup.astro
@@ -32,7 +32,7 @@ import { cn } from '@/lib/utils';
  * </Popup>
  * ```
  * 
- * @example When you need to fit a novel in there
+ * @example
  * ```astro
  * <Popup size="large" color="light-blue">
  *   <slot />
@@ -46,13 +46,13 @@ import { cn } from '@/lib/utils';
  * </Popup>
  * ```
  * Props:
- * @param size - 'large' for detailed content, 'small' for quick messages
+ * @param size - 'large' for detailed content, 'medium' for moderate content, 'small' for quick messages
  * @param color - Pick a color that matches your vibe (see list above)
  * @param class - Throw in extra CSS classes if you need custom styling
  */
 
 export interface Props {
-  size?: 'large' | 'small';
+  size?: 'large' | 'medium' | 'small';
   color?: 'black' | 'vivid-pink' | 'light-green' | 'light-blue' | 'light-pink' | 'light-beige';
   class?: string;
 }
@@ -70,6 +70,12 @@ const sizeConfig = {
     minHeight: '400px',
     contentWidth: '80%',
     contentHeight: '70%'
+  },
+  medium: {
+    aspectRatio: '365/575',
+    minHeight: '300px',
+    contentWidth: '78%',
+    contentHeight: '68%'
   },
   small: {
     aspectRatio: '342/366',
@@ -103,7 +109,7 @@ const borderSvg = `/images/popup-borders/popup-border-${size}-${color}.svg`;
   <div 
     class="absolute inset-0 z-10"
     style={`
-      padding: ${size === 'large' ? '15%' : '12%'};
+      padding: ${size === 'large' ? '15%' : size === 'medium' ? '13%' : '12%'};
     `}
   >
     <div class={cn("w-full h-full overflow-hidden", additionalClasses)}>
@@ -157,6 +163,11 @@ const borderSvg = `/images/popup-borders/popup-border-${size}-${color}.svg`;
   .popup-container[data-size="large"] .popup-content-clip {
     /* Large popups have more decorative border space */
     margin: 2%;
+  }
+  
+  .popup-container[data-size="medium"] .popup-content-clip {
+    /* Medium popups have moderate decorative border space */
+    margin: 1.5%;
   }
   
   .popup-container[data-size="small"] .popup-content-clip {


### PR DESCRIPTION
# Summary
- Add medium size option to Popup component with 4 color variants.
- Include medium-sized popup SVG borders (light-beige, light-green, light-pink, vivid-pink)
- this size of popup isn't declared in global components but appearing in the FD prototype so I suggest add this size krub.

## Preview
![Screenshot_2025-07-09_at_9 50 39](https://github.com/user-attachments/assets/c5762993-b1ab-4c12-afcc-cd22f33aabde)
