### PR TITLE
[Feat][Firstdate] Add FM Night menu

### DIFF
--- a/src/components/firstdate/Navbar.astro
+++ b/src/components/firstdate/Navbar.astro
@@ -70,6 +70,9 @@ import ButtonFd from "@common/ButtonFd.astro";
         <a href="/firstdate/events/rpkm">รับเพื่อนก้าวใหม่</a>
       </li>
       <li>
+        <a href="/firstdate/events/freshmen-night">Freshmen Night</a>
+      </li>
+      <li>
         <a href="/profile">PROFILE</a>
       </li>
       <li>

--- a/src/pages/firstdate/events/[eventId]/index.astro
+++ b/src/pages/firstdate/events/[eventId]/index.astro
@@ -111,7 +111,7 @@ if (eventStatus.isRegistered && eventStatus.checkinData) {
 
               {(eventType === "firstdate" ||
                 eventType === "freshmen-night") && (
-                <ButtonFd class="mb-2" color="white" href="/firstdate/map/">
+                <ButtonFd class="mb-2" color="white" href="/firstdate/maps/">
                   แผนที่งาน
                 </ButtonFd>
               )}

--- a/src/pages/firstdate/home/index.astro
+++ b/src/pages/firstdate/home/index.astro
@@ -58,6 +58,14 @@ import Layout from "@/layouts/firstdate/WithNavbar.astro";
           >
             รับเพื่อนก้าวใหม่
           </ButtonFd>
+          <ButtonFd
+            variant="fill"
+            color="white"
+            href="/firstdate/events/freshmen-night/"
+            class="w-full"
+          >
+            Freshmen Night
+          </ButtonFd>
         </div>
       </div>
     </div>

--- a/src/pages/staff/event/index.astro
+++ b/src/pages/staff/event/index.astro
@@ -330,8 +330,6 @@ import StaffWithNavbar from "@/layouts/firstdate/StaffWithNavbar.astro";
 
 <script>
   import { api } from "@/lib/api";
-  import { EVENT_CONFIGS, getEventStatus } from "@/lib/eventAPI";
-  import type { EventType } from "@/lib/eventAPI";
 
   interface QrFormData {
     studentId: string;
@@ -539,41 +537,74 @@ import StaffWithNavbar from "@/layouts/firstdate/StaffWithNavbar.astro";
   // }
 
   async function determineActiveEvent(): Promise<any> {
-    const currentDate = new Date(); // Uses local timezone
-
-    // Date ranges for events
-    const firstdateStart = new Date("2025-07-19T00:00:00+07:00");
-    const firstdateEnd = new Date("2025-07-19T23:59:59+07:00");
-
-    const rpkmStart = new Date("2025-08-02T00:00:00+07:00");
-    const rpkmEnd = new Date("2025-08-02T23:59:59+07:00");
-
-    let activeEventId: EventType | null = null;
-
-    // Check if current date falls within firstdate period
-    if (currentDate >= firstdateStart && currentDate <= firstdateEnd) {
-      activeEventId = "firstdate";
-    }
-    // Check if current date falls within rpkm period
-    else if (currentDate >= rpkmStart && currentDate <= rpkmEnd) {
-      activeEventId = "rpkm";
-    }
-
-    // If no active event found, return null
-    if (!activeEventId) {
-      return null;
-    }
-
-    // Return the active event data
-    return {
-      eventId: activeEventId,
-      eventConfig: EVENT_CONFIGS[activeEventId],
-      eventStatus: {
-        isRegistered: false,
-        isLate: false,
-        isComingSoon: false,
-      },
+    const events = ["FRESHMENNIGHT", "RPKM", "FIRSTDATE"] as const;
+    const eventTitles: Record<string, string> = {
+      FRESHMENNIGHT: "Freshmen Night",
+      RPKM: "รับเพื่อนก้าวใหม่",
+      FIRSTDATE: "First Date",
     };
+
+    for (const eventId of events) {
+      try {
+        const eventResponse = await api.get(`/checkin/${eventId}`);
+
+        if (eventResponse.success) {
+          return {
+            eventId: eventId,
+            eventConfig: {
+              title: eventTitles[eventId] || eventId,
+              schedule: "กำลังเปิดให้ลงทะเบียน",
+            },
+            eventStatus: {
+              isRegistered: true,
+              isLate: false,
+              isComingSoon: false,
+            },
+          };
+        } else if (eventResponse.error === "Check-in not found") {
+          return {
+            eventId: eventId,
+            eventConfig: {
+              title: eventTitles[eventId] || eventId,
+              schedule: "กำลังเปิดให้ลงทะเบียน",
+            },
+            eventStatus: {
+              isRegistered: false,
+              isLate: false,
+              isComingSoon: false,
+            },
+          };
+        }
+      } catch (eventError: any) {
+        const eventErrorMessage = eventError?.message || "";
+
+        if (
+          eventError?.status === 400 ||
+          eventErrorMessage.includes("not allowed before") ||
+          eventErrorMessage.includes("not allowed after") ||
+          eventErrorMessage.includes("Checking is not allowed")
+        ) {
+          continue;
+        }
+
+        if (eventError?.status !== 404) {
+          return {
+            eventId: eventId,
+            eventConfig: {
+              title: eventTitles[eventId] || eventId,
+              schedule: "กำลังเปิดให้ลงทะเบียน",
+            },
+            eventStatus: {
+              isRegistered: false,
+              isLate: false,
+              isComingSoon: false,
+            },
+          };
+        }
+      }
+    }
+
+    return null;
   }
 
   function updateEventUI(activeEventData: any): void {


### PR DESCRIPTION
# Summary
- Added FM night button, nav menu for `/firstdate/events/freshmen-night/`
- rm event checking hardcode >> use loop to check the event
- for staff role nothing changed just fetch the opening event from backend
- all fm night related features are tested. (Locally passed)

## Preview
<img width="750" height="2046" alt="localhost_4321_firstdate_home(iPhone SE) (1)" src="https://github.com/user-attachments/assets/53d92d2c-4920-44a1-82fb-1cb51b788fe3" />
<img width="750" height="2046" alt="localhost_4321_firstdate_home(iPhone SE)" src="https://github.com/user-attachments/assets/6a6f20ae-5d97-48df-8f6b-43ba1fb746e4" />
<img width="750" height="2190" alt="localhost_4321_firstdate_events_freshmen-night_(iPhone SE)" src="https://github.com/user-attachments/assets/c78e3cd9-062e-4d95-becd-ac14fc7f0473" />
